### PR TITLE
fix: for linux stop publishing trimmed releases

### DIFF
--- a/Source/PabloDraw/PabloDraw.csproj
+++ b/Source/PabloDraw/PabloDraw.csproj
@@ -29,7 +29,7 @@
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <DefineConstants>LINUX</DefineConstants>
     <TrimMode>Link</TrimMode>
-    <PublishTrimmed>True</PublishTrimmed>
+    <!-- <PublishTrimmed>True</PublishTrimmed> -->
   </PropertyGroup>
 
   <PropertyGroup Condition="$(BuildTarget) == 'Mac'">


### PR DESCRIPTION
This fix addresses runtime instability caused by aggressive trimming in the build process, allowing the application to function correctly with GTK components.

should help #112 #106 #104 #102 #91